### PR TITLE
fix: support hebrew characters in feature properties by adding UTF-8 encoding to shapefile reader

### DIFF
--- a/src/files/shapefile/core/shapeFileReader.ts
+++ b/src/files/shapefile/core/shapeFileReader.ts
@@ -25,7 +25,9 @@ export class ShapefileChunkReader {
 
     const chunkBuilder = new ChunkBuilder(this.options.maxVerticesPerChunk, chunkIndex);
     try {
-      const reader = await open(shapefilePath);
+      const dbfPath = shapefilePath.replace(/\.shp$/i, '.dbf');
+      //support feature properties with hebrew characters by setting encoding to 'utf-8'
+      const reader = await open(shapefilePath, dbfPath, { encoding: 'utf-8' });
 
       this.options.logger?.info({ msg: 'Reading started' });
       let readStart = performance.now();

--- a/tests/unit/files/shapefile/shapeFileReader.spec.ts
+++ b/tests/unit/files/shapefile/shapeFileReader.spec.ts
@@ -12,6 +12,7 @@ import { MetricsManager } from '../../../../src/files/shapefile/core/metricsMana
 import * as vertices from '../../../../src/geo/vertices';
 
 const shapefilePath = '/path/to/shapefile.shp';
+const dbfFilePath = shapefilePath.replace(/\.shp$/i, '.dbf');
 
 // Mock all dependencies
 jest.mock('shapefile');
@@ -123,7 +124,7 @@ describe('ShapefileChunkReader', () => {
 
       await reader.readAndProcess(shapefilePath, { process: mockProcessor });
 
-      expect(mockShapefile.open).toHaveBeenCalledWith(shapefilePath);
+      expect(mockShapefile.open).toHaveBeenCalledWith(shapefilePath, dbfFilePath, { encoding: 'utf-8' });
       expect(mockChunkBuilder.addFeature).toHaveBeenCalledTimes(2);
       expect(mockProcessor).toHaveBeenCalledTimes(1);
       expect(mockOptions.stateManager?.saveState).toHaveBeenCalled();


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Further  information:
support hebrew characters in feature properties by adding UTF-8 encoding to shapefile reader