### PR TITLE
feat: footprint to tiles (MAPCO-11173)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,8 +49,6 @@ jobs:
         uses: actions/checkout@v6
       - name: Init nodejs
         uses: MapColonies/shared-workflows/actions/init-npm@init-npm-v1
-        with:
-          node-version: ${{ matrix.node }}
       - name: Pack the package
         run: npm pack
       - name: get properties

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,7 +48,9 @@ jobs:
       - name: Check out TS Project Git repository
         uses: actions/checkout@v6
       - name: Init nodejs
-        uses: ./.github/actions/init-npm
+        uses: MapColonies/shared-workflows/actions/init-npm@init-npm-v1
+        with:
+          node-version: ${{ matrix.node }}
       - name: Pack the package
         run: npm pack
       - name: get properties

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,6 +49,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Init nodejs
         uses: MapColonies/shared-workflows/actions/init-npm@init-npm-v1
+        with:
+          node-version: ${{ matrix.node }}
       - name: Pack the package
         run: npm pack
       - name: get properties

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -77,4 +77,4 @@ jobs:
             }
             ```
             The link will expire in a week :hourglass:
-          
+  

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Init nodejs
         uses: MapColonies/shared-workflows/actions/init-npm@init-npm-v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 24.x
       - name: Pack the package
         run: npm pack
       - name: get properties

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -76,4 +76,5 @@ jobs:
               }
             }
             ```
-            The link will expire in a week :hourglass:          
+            The link will expire in a week :hourglass:
+          

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,3 +39,39 @@ jobs:
         uses: MapColonies/shared-workflows/actions/eslint@eslint-v1.0.1
         with:
           node_version: ${{ matrix.node }}
+
+  upload_package:
+    needs: [eslint, tests]
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out TS Project Git repository
+        uses: actions/checkout@v6
+      - name: Init nodejs
+        uses: ./.github/actions/init-npm
+      - name: Pack the package
+        run: npm pack
+      - name: get properties
+        id: json_properties
+        uses: ActionsTools/read-json-action@main
+        with:
+          file_path: 'package.json'
+      - uses: azure/CLI@v2
+        with:
+          inlineScript: |
+            az storage blob upload --name mc-utils-${{ github.sha }}.tgz --account-name ghatmpstorage --container-name=npm-packages --file map-colonies-mc-utils-${{steps.json_properties.outputs.version}}.tgz --sas-token "${{ secrets.SAS_TOKEN }}"
+      - name: Comment on PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            Hi it is me, your friendly bot helper! :wave:
+            I've packed this commit for you :blush:
+            You can install it like this:
+            ```json
+            {
+              "dependencies": {
+                  "@map-colonies/mc-utils": "https://ghatmpstorage.blob.core.windows.net/npm-packages/mc-utils-${{ github.sha }}.tgz"
+              }
+            }
+            ```
+            The link will expire in a week :hourglass:          

--- a/README.md
+++ b/README.md
@@ -3,8 +3,28 @@ this is general utilities for usage in Map Colonies project.
 
 # included components
  - [http client](#http-client)
+ - [footprint to tile ranges](#footprint-to-tile-ranges)
 
 # usage
+ ## footprint to tile ranges
+ `footprintToTileRanges(footprint, { minZoom, maxZoom })` lazily computes the tile ranges intersecting a footprint (Polygon / MultiPolygon / Feature, holes supported) for every zoom level in the span, on the WGS84 geodetic 2:1 grid.
+
+ it uses hierarchical descent (see `docs/adr/0001-hierarchical-precompute-in-mc-utils.md`): fully-interior subtrees are emitted as compressed ranges with no per-tile work, so memory stays flat regardless of how many tiles the footprint covers. a tile touching the footprint with zero overlap area counts as intersecting. ranges of the same zoom are disjoint; their order is deterministic but unspecified.
+
+ typical use is tile-cache invalidation: expand each range to your cache's key format and batch-delete.
+
+```typescript
+import { footprintToTileRanges } from '@map-colonies/mc-utils';
+
+for (const range of footprintToTileRanges(footprint, { minZoom: 0, maxZoom: 18 })) {
+  for (let x = range.minX; x <= range.maxX; x++) {
+    for (let y = range.minY; y <= range.maxY; y++) {
+      actionOnTile(range.zoom, x, y); // e.g. batch UNLINK keys in redis
+    }
+  }
+}
+```
+
  ## http client
  this is abstract base class for sending http request with logging and request retries.
 

--- a/simulations/footprintToTileRanges.html
+++ b/simulations/footprintToTileRanges.html
@@ -1,0 +1,835 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>footprintToTileRanges — flow debugger</title>
+    <style>
+      :root {
+        --paper: #fafaf7;
+        --panel: #ffffff;
+        --ink: #26251f;
+        --mut: #6b6a63;
+        --line: #e4e2d8;
+        --orange: #d85a30;
+        --orangeT: #fbeae2;
+        --green: #1d9e75;
+        --greenF: #bfe8d6;
+        --greenT: #e4f5ee;
+        --pruned: #efeee8;
+        --prunedEdge: #dddcd2;
+        --blue: #2b5fd9;
+        --red: #c2402a;
+        --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+      }
+      header {
+        border-bottom: 1px solid var(--line);
+        padding: 14px 20px;
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+        flex-wrap: wrap;
+      }
+      .eyebrow {
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        color: var(--mut);
+        font-weight: 700;
+      }
+      .fn {
+        font-family: var(--mono);
+        font-size: 17px;
+        font-weight: 700;
+      }
+      button {
+        background: var(--panel);
+        color: var(--ink);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 7px 14px;
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      button.primary {
+        background: var(--ink);
+        color: #fff;
+        border-color: var(--ink);
+      }
+      button:focus-visible,
+      input:focus-visible,
+      textarea:focus-visible {
+        outline: 2px solid var(--blue);
+        outline-offset: 1px;
+      }
+      #inputDrawer {
+        border-bottom: 1px solid var(--line);
+        padding: 14px 20px;
+        background: var(--panel);
+      }
+      .drawerGrid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 20px;
+      }
+      .geoCol {
+        flex: 1 1 380px;
+        min-width: 300px;
+      }
+      .label {
+        font-size: 12px;
+        color: var(--mut);
+        margin-bottom: 6px;
+      }
+      textarea {
+        width: 100%;
+        height: 150px;
+        font-family: var(--mono);
+        font-size: 12px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 10px;
+        color: var(--ink);
+        background: var(--paper);
+        resize: vertical;
+      }
+      .sideCol {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .presets {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .presets button {
+        text-align: left;
+        font-weight: 500;
+      }
+      input[type='number'] {
+        width: 64px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 4px 8px;
+        font-family: var(--mono);
+        font-size: 13px;
+        background: var(--panel);
+      }
+      #err {
+        margin-top: 10px;
+        color: var(--red);
+        font-size: 13px;
+        font-family: var(--mono);
+      }
+      main {
+        display: flex;
+        flex-wrap: wrap;
+        min-height: 430px;
+      }
+      #mapWrap {
+        flex: 1 1 440px;
+        min-width: 320px;
+        height: 460px;
+        position: relative;
+        border-right: 1px solid var(--line);
+      }
+      canvas {
+        display: block;
+      }
+      #viewBtns {
+        position: absolute;
+        left: 12px;
+        bottom: 10px;
+        display: flex;
+        gap: 6px;
+      }
+      #viewBtns button {
+        padding: 3px 10px;
+        font-size: 11px;
+        color: var(--mut);
+      }
+      #viewBtns button.on {
+        background: var(--ink);
+        color: #fff;
+        border-color: var(--ink);
+      }
+      #legend {
+        position: absolute;
+        right: 12px;
+        top: 10px;
+        font-size: 11px;
+        color: var(--mut);
+        background: rgba(255, 255, 255, 0.85);
+        padding: 4px 8px;
+        border-radius: 6px;
+        border: 1px solid var(--line);
+      }
+      #ledger {
+        flex: 1 1 380px;
+        min-width: 320px;
+        background: var(--panel);
+        padding: 16px 20px;
+      }
+      .traceHead {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 8px;
+      }
+      #stepCount {
+        font-family: var(--mono);
+        font-size: 13px;
+      }
+      #chip {
+        margin-left: auto;
+        font-family: var(--mono);
+        font-size: 12px;
+        font-weight: 700;
+        padding: 3px 10px;
+        border-radius: 999px;
+      }
+      .mono {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        line-height: 1.75;
+      }
+      .mut {
+        color: var(--mut);
+      }
+      .stack {
+        color: var(--mut);
+        font-size: 11.5px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .callLine {
+        font-size: 14px;
+        font-weight: 700;
+        margin: 6px 0 2px;
+      }
+      .pathLabel {
+        margin: 8px 0 2px;
+        font-weight: 700;
+        font-family: system-ui, sans-serif;
+      }
+      #tallies {
+        margin-top: 14px;
+        padding-top: 10px;
+        border-top: 1px solid var(--line);
+        font-family: var(--mono);
+        font-size: 13px;
+        display: flex;
+        gap: 18px;
+        flex-wrap: wrap;
+      }
+      #transport {
+        border-top: 1px solid var(--line);
+        padding: 12px 20px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex-wrap: wrap;
+        background: var(--panel);
+      }
+      #scrub {
+        flex: 1 1 200px;
+        accent-color: var(--ink);
+      }
+      #speed {
+        width: 90px;
+        accent-color: var(--ink);
+      }
+      .speedLbl {
+        font-size: 12px;
+        color: var(--mut);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      footer {
+        padding: 10px 20px;
+        font-size: 11px;
+        color: var(--mut);
+      }
+      .hidden {
+        display: none !important;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <span class="eyebrow">FLOW DEBUGGER</span>
+      <span class="fn">footprintToTileRanges(footprint, span)</span>
+      <button id="toggleInput" style="margin-left: auto">Hide footprint input</button>
+    </header>
+
+    <div id="inputDrawer">
+      <div class="drawerGrid">
+        <div class="geoCol">
+          <div class="label">Footprint GeoJSON — Polygon, MultiPolygon, or Feature; holes supported</div>
+          <textarea id="geo" spellcheck="false"></textarea>
+        </div>
+        <div class="sideCol">
+          <div>
+            <div class="label">Presets</div>
+            <div class="presets" id="presets"></div>
+          </div>
+          <div>
+            <div class="label">Zoom span (inclusive)</div>
+            <input type="number" id="minZoom" min="0" max="22" value="0" aria-label="minZoom" />
+            <span class="mono mut">..</span>
+            <input type="number" id="maxZoom" min="0" max="22" value="5" aria-label="maxZoom" />
+          </div>
+          <button class="primary" id="runBtn">Run trace</button>
+        </div>
+      </div>
+      <div id="err"></div>
+    </div>
+
+    <main>
+      <div id="mapWrap">
+        <canvas id="cv"></canvas>
+        <div id="viewBtns" class="hidden">
+          <button data-v="auto" class="on">auto</button>
+          <button data-v="world">world</button>
+          <button data-v="fit">fit</button>
+        </div>
+        <div id="legend" class="hidden">
+          <span style="color: var(--green)">&#9632;</span> interior&nbsp;&nbsp; <span style="color: var(--orange)">&#9633;</span> boundary&nbsp;&nbsp;
+          <span style="color: var(--prunedEdge)">&#9632;</span> pruned&nbsp;&nbsp; <span style="color: var(--blue)">&#9633;</span> current
+        </div>
+      </div>
+      <div id="ledger">
+        <div id="intro" style="color: var(--mut); font-size: 14px; line-height: 1.6">
+          Paste a footprint (or pick a preset), set the zoom span, and run the trace. Then scrub, play, or step with &larr; &rarr; keys; space toggles
+          play. Scope IDs (FT-3.A / B / C) match the Confluence page anchors.
+        </div>
+        <div id="trace" class="hidden">
+          <div class="traceHead">
+            <span class="eyebrow">EXECUTION TRACE</span>
+            <span id="stepCount"></span>
+            <span id="chip"></span>
+          </div>
+          <div class="mono" id="lines"></div>
+          <div id="tallies"></div>
+        </div>
+      </div>
+    </main>
+
+    <div id="transport" class="hidden">
+      <button id="restart" aria-label="Restart">&#9198;</button>
+      <button id="back" aria-label="Step back">&larr;</button>
+      <button id="playBtn" class="primary" style="min-width: 82px">Play</button>
+      <button id="fwd" aria-label="Step forward">&rarr;</button>
+      <input type="range" id="scrub" min="0" max="0" value="0" aria-label="Scrub steps" />
+      <label class="speedLbl"
+        >speed
+        <input type="range" id="speed" min="1" max="30" value="6" aria-label="Playback speed" />
+        <span class="mono" id="speedVal">6/s</span>
+      </label>
+    </div>
+
+    <footer>
+      Faithful port of footprintToTileRanges on the WGS84 geodetic grid (two zoom-0 roots, 180/2^z&deg; tiles). Scope IDs match the Confluence pages:
+      FT-&hellip; and LB-&hellip;. Runs fully offline.
+    </footer>
+
+    <script>
+      'use strict';
+      // ── faithful ports of the algorithm ──────────────────────────────────────────
+      const GRID_MIN_LON = -180,
+        GRID_MIN_LAT = -90,
+        MAX_STEPS = 4000;
+      const degreesPerTile = (z) => 180 / Math.pow(2, z);
+      const tileBounds = (z, x, y) => {
+        const s = degreesPerTile(z),
+          minLon = GRID_MIN_LON + x * s,
+          minLat = GRID_MIN_LAT + y * s;
+        return { minLon, minLat, maxLon: minLon + s, maxLat: minLat + s };
+      };
+      function segmentIntersectsBounds(e, b) {
+        const dx = e.x2 - e.x1,
+          dy = e.y2 - e.y1;
+        const p = [-dx, dx, -dy, dy];
+        const q = [e.x1 - b.minLon, b.maxLon - e.x1, e.y1 - b.minLat, b.maxLat - e.y1];
+        let t0 = 0,
+          t1 = 1;
+        for (let i = 0; i < 4; i++) {
+          if (p[i] === 0) {
+            if (q[i] < 0) return false;
+          } else {
+            const r = q[i] / p[i];
+            if (p[i] < 0) {
+              if (r > t1) return false;
+              if (r > t0) t0 = r;
+            } else {
+              if (r < t0) return false;
+              if (r < t1) t1 = r;
+            }
+          }
+        }
+        return true;
+      }
+      function rayCrossings(lon, lat, rings) {
+        let n = 0;
+        for (const ring of rings)
+          for (let i = 0; i < ring.length - 1; i++) {
+            const x1 = ring[i][0],
+              y1 = ring[i][1],
+              x2 = ring[i + 1][0],
+              y2 = ring[i + 1][1];
+            if ((y1 <= lat && y2 > lat) || (y2 <= lat && y1 > lat)) {
+              const xc = x1 + ((lat - y1) * (x2 - x1)) / (y2 - y1);
+              if (xc > lon) n++;
+            }
+          }
+        return n;
+      }
+      function parseFootprint(text) {
+        let g;
+        try {
+          g = JSON.parse(text);
+        } catch {
+          throw new Error('Not valid JSON — check for missing brackets or commas.');
+        }
+        if (g && g.type === 'Feature') g = g.geometry;
+        if (!g || (g.type !== 'Polygon' && g.type !== 'MultiPolygon'))
+          throw new Error('Footprint must be a Polygon, MultiPolygon, or a Feature wrapping one.');
+        let rings = g.type === 'Polygon' ? g.coordinates : g.coordinates.flat();
+        if (!rings.length || rings.some((r) => !Array.isArray(r) || r.length < 3)) throw new Error('Each ring needs at least 3 positions.');
+        return rings.map((r) => {
+          const f = r[0],
+            l = r[r.length - 1];
+          return f[0] === l[0] && f[1] === l[1] ? r : r.concat([r[0]]); // auto-close open rings
+        });
+      }
+      function buildTrace(rings, span) {
+        if (span.minZoom > span.maxZoom) throw new Error(`minZoom [${span.minZoom}] must not be greater than maxZoom [${span.maxZoom}]`);
+        if (span.minZoom < 0 || span.maxZoom > 22)
+          throw new Error(`zoom span [${span.minZoom}, ${span.maxZoom}] exceeds the supported range [0, 22]`);
+        const edges = [];
+        for (const r of rings) for (let i = 0; i < r.length - 1; i++) edges.push({ x1: r[i][0], y1: r[i][1], x2: r[i + 1][0], y2: r[i + 1][1] });
+        const trace = [];
+        function descend(z, x, y, parentEdges, stack) {
+          if (trace.length >= MAX_STEPS) throw new Error(`Trace exceeds ${MAX_STEPS} steps — lower maxZoom or simplify the footprint.`);
+          const b = tileBounds(z, x, y);
+          const clipped = parentEdges.filter((e) => segmentIntersectsBounds(e, b));
+          const entry = { z, x, y, b, nIn: parentEdges.length, nClip: clipped.length, stack: stack.concat([[z, x, y]]) };
+          if (clipped.length === 0) {
+            const cLon = (b.minLon + b.maxLon) / 2,
+              cLat = (b.minLat + b.maxLat) / 2;
+            const n = rayCrossings(cLon, cLat, rings),
+              inside = n % 2 === 1;
+            entry.center = [cLon, cLat];
+            entry.ncross = n;
+            entry.path = inside ? 'B' : 'C';
+            entry.emitted = inside ? Math.max(0, span.maxZoom - Math.max(z, span.minZoom) + 1) : 0;
+            trace.push(entry);
+            return;
+          }
+          entry.path = 'A';
+          entry.emitted = z >= span.minZoom ? 1 : 0;
+          trace.push(entry);
+          if (z < span.maxZoom) {
+            descend(z + 1, 2 * x, 2 * y, clipped, entry.stack);
+            descend(z + 1, 2 * x + 1, 2 * y, clipped, entry.stack);
+            descend(z + 1, 2 * x, 2 * y + 1, clipped, entry.stack);
+            descend(z + 1, 2 * x + 1, 2 * y + 1, clipped, entry.stack);
+          }
+        }
+        descend(0, 0, 0, edges, []); // west hemisphere root
+        descend(0, 1, 0, edges, []); // east hemisphere root
+        let em = 0,
+          pr = 0;
+        const emittedPrefix = [],
+          prunedPrefix = [];
+        for (const t of trace) {
+          em += t.emitted;
+          pr += t.path === 'C' ? 1 : 0;
+          emittedPrefix.push(em);
+          prunedPrefix.push(pr);
+        }
+        return { trace, emittedPrefix, prunedPrefix, totalRanges: em, span };
+      }
+
+      // ── presets ───────────────────────────────────────────────────────────────────
+      const PRESETS = {
+        'Australia + desert hole': {
+          span: { minZoom: 0, maxZoom: 5 },
+          geo: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [113.5, -22],
+                [115, -34],
+                [124, -33],
+                [129.5, -31.5],
+                [137.5, -35.5],
+                [140.5, -38],
+                [146.5, -39],
+                [150, -37.5],
+                [153.5, -28.5],
+                [146, -18.5],
+                [142, -10.8],
+                [135.5, -12],
+                [131, -11.5],
+                [125.5, -14],
+                [121.5, -19],
+                [113.5, -22],
+              ],
+              [
+                [126, -25],
+                [133, -26],
+                [132, -30],
+                [125, -29],
+                [126, -25],
+              ],
+            ],
+          },
+        },
+        'MultiPolygon (two islands)': {
+          span: { minZoom: 0, maxZoom: 6 },
+          geo: {
+            type: 'MultiPolygon',
+            coordinates: [
+              [
+                [
+                  [12.4, 38.2],
+                  [15.6, 38.3],
+                  [15.1, 36.7],
+                  [12.4, 37.5],
+                  [12.4, 38.2],
+                ],
+              ],
+              [
+                [
+                  [8.2, 41.2],
+                  [9.6, 41.3],
+                  [9.5, 39.1],
+                  [8.4, 38.9],
+                  [8.2, 41.2],
+                ],
+              ],
+            ],
+          },
+        },
+        'Tiny triangle (fast)': {
+          span: { minZoom: 0, maxZoom: 4 },
+          geo: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [34, 31],
+                [36, 33.5],
+                [35, 29.5],
+                [34, 31],
+              ],
+            ],
+          },
+        },
+      };
+
+      // ── state ─────────────────────────────────────────────────────────────────────
+      const $ = (id) => document.getElementById(id);
+      const css = (v) => getComputedStyle(document.documentElement).getPropertyValue(v).trim();
+      const PATH_META = {
+        A: { chip: 'FT-3.A', label: 'Boundary tile — emit 1×1, recurse', fg: css('--orange'), bg: css('--orangeT') },
+        B: { chip: 'FT-3.B', label: 'Interior — settle whole subtree', fg: css('--green'), bg: css('--greenT') },
+        C: { chip: 'FT-3.C', label: 'Exterior — prune subtree', fg: css('--mut'), bg: css('--pruned') },
+      };
+      const fmt = (v) => (Math.abs(v) < 1e-9 ? '0' : v.toFixed(3).replace(/\.?0+$/, ''));
+      let run = null,
+        step = 0,
+        playing = false,
+        timer = null,
+        speed = 6,
+        viewMode = 'auto';
+
+      // ── run ───────────────────────────────────────────────────────────────────────
+      function runTrace() {
+        stop();
+        try {
+          const rings = parseFootprint($('geo').value);
+          const built = buildTrace(rings, { minZoom: +$('minZoom').value, maxZoom: +$('maxZoom').value });
+          let bb = [Infinity, Infinity, -Infinity, -Infinity];
+          for (const r of rings) for (const p of r) bb = [Math.min(bb[0], p[0]), Math.min(bb[1], p[1]), Math.max(bb[2], p[0]), Math.max(bb[3], p[1])];
+          run = Object.assign(built, { rings, bbox: bb });
+          step = 0;
+          $('err').textContent = '';
+          setDrawer(false);
+          $('intro').classList.add('hidden');
+          ['trace', 'transport', 'viewBtns', 'legend'].forEach((id) => $(id).classList.remove('hidden'));
+          $('scrub').max = run.trace.length - 1;
+          render();
+        } catch (e) {
+          $('err').textContent = e.message;
+        }
+      }
+
+      // ── view + canvas ─────────────────────────────────────────────────────────────
+      function currentView() {
+        const world = { minLon: -184, minLat: -92, maxLon: 184, maxLat: 92 };
+        if (!run) return world;
+        const [a, b, c, d] = run.bbox;
+        const px = Math.max((c - a) * 0.35, 2),
+          py = Math.max((d - b) * 0.35, 2);
+        const fit = { minLon: a - px, minLat: b - py, maxLon: c + px, maxLat: d + py };
+        if (viewMode === 'world') return world;
+        if (viewMode === 'fit') return fit;
+        return run.trace[step].z <= 1 ? world : fit;
+      }
+      function draw() {
+        const wrap = $('mapWrap'),
+          cv = $('cv');
+        const dpr = window.devicePixelRatio || 1,
+          W = wrap.clientWidth,
+          H = wrap.clientHeight;
+        cv.width = W * dpr;
+        cv.height = H * dpr;
+        cv.style.width = W + 'px';
+        cv.style.height = H + 'px';
+        const g = cv.getContext('2d');
+        g.setTransform(dpr, 0, 0, dpr, 0, 0);
+        g.fillStyle = css('--paper');
+        g.fillRect(0, 0, W, H);
+        if (!run) {
+          g.fillStyle = css('--mut');
+          g.font = '13px ' + css('--mono');
+          g.textAlign = 'center';
+          g.fillText('Run a trace to see the tile grid here', W / 2, H / 2);
+          return;
+        }
+        const v = currentView();
+        const s = Math.min(W / (v.maxLon - v.minLon), H / (v.maxLat - v.minLat));
+        const ox = (W - (v.maxLon - v.minLon) * s) / 2,
+          oy = (H - (v.maxLat - v.minLat) * s) / 2;
+        const X = (lon) => ox + (lon - v.minLon) * s;
+        const Y = (lat) => H - oy - (lat - v.minLat) * s;
+        const rect = (b) => [X(b.minLon), Y(b.maxLat), (b.maxLon - b.minLon) * s, (b.maxLat - b.minLat) * s];
+
+        g.strokeStyle = css('--line');
+        g.lineWidth = 1;
+        g.strokeRect(X(-180), Y(90), 360 * s, 180 * s);
+        g.beginPath();
+        g.moveTo(X(0), Y(90));
+        g.lineTo(X(0), Y(-90));
+        g.stroke();
+
+        for (let k = 0; k <= step; k++) {
+          const t = run.trace[k],
+            r = rect(t.b);
+          if (t.path === 'B') {
+            g.fillStyle = css('--greenF');
+            g.fillRect(...r);
+            g.strokeStyle = css('--green');
+            g.lineWidth = 0.6;
+            g.strokeRect(...r);
+          } else if (t.path === 'C') {
+            g.fillStyle = css('--pruned');
+            g.fillRect(...r);
+            g.strokeStyle = css('--prunedEdge');
+            g.lineWidth = 0.5;
+            g.strokeRect(...r);
+          } else {
+            g.strokeStyle = css('--orange');
+            g.lineWidth = 1.1;
+            g.strokeRect(...r);
+          }
+        }
+        g.strokeStyle = css('--ink');
+        g.lineWidth = 1.8;
+        g.lineJoin = 'round';
+        for (const ring of run.rings) {
+          g.beginPath();
+          ring.forEach((p, i) => (i ? g.lineTo(X(p[0]), Y(p[1])) : g.moveTo(X(p[0]), Y(p[1]))));
+          g.stroke();
+        }
+        const cur = run.trace[step],
+          r = rect(cur.b);
+        g.strokeStyle = css('--blue');
+        g.lineWidth = 2.6;
+        g.strokeRect(...r);
+        if (cur.center) {
+          g.fillStyle = css('--blue');
+          g.beginPath();
+          g.arc(X(cur.center[0]), Y(cur.center[1]), 3.5, 0, Math.PI * 2);
+          g.fill();
+        }
+      }
+
+      // ── ledger ────────────────────────────────────────────────────────────────────
+      function esc(x) {
+        return String(x);
+      }
+      function renderLedger() {
+        const t = run.trace[step],
+          pm = PATH_META[t.path],
+          span = run.span;
+        $('stepCount').textContent = `step ${step + 1} / ${run.trace.length}`;
+        const chip = $('chip');
+        chip.textContent = pm.chip;
+        chip.style.background = pm.bg;
+        chip.style.color = pm.fg;
+        const rows = [];
+        rows.push(`<div class="stack">stack: ${t.stack.map((s) => `(${s[0]},${s[1]},${s[2]})`).join(' \u2192 ')}</div>`);
+        const rootNote = t.z === 0 ? `<span class="mut" style="font-weight:400"> — ${t.x === 0 ? 'west' : 'east'} hemisphere root</span>` : '';
+        rows.push(`<div class="callLine">descend(z=${t.z}, x=${t.x}, y=${t.y})${rootNote}</div>`);
+        rows.push(`<div class="mut">degreesPerTile(${t.z}) = ${fmt(degreesPerTile(t.z))}&deg;</div>`);
+        rows.push(
+          `<div class="mut">tileBounds \u2192 lon [${fmt(t.b.minLon)}, ${fmt(t.b.maxLon)}] lat [${fmt(t.b.minLat)}, ${fmt(t.b.maxLat)}]</div>`
+        );
+        rows.push(`<div>segmentIntersectsBounds \u00d7 ${t.nIn} parent edges \u2192 <b>${t.nClip} cross</b></div>`);
+        if (t.path !== 'A') {
+          const verdict = t.path === 'B' ? 'odd \u2192 inside' : 'even \u2192 outside';
+          rows.push(
+            `<div>pointInRings(${fmt(t.center[0])}&deg;, ${fmt(t.center[1])}&deg;) \u2192 ${t.ncross} crossing${t.ncross === 1 ? '' : 's'} \u2192 <b style="color:${pm.fg}">${verdict}</b></div>`
+          );
+        }
+        rows.push(`<div class="pathLabel" style="color:${pm.fg}">${pm.label}</div>`);
+        if (t.path === 'A') {
+          rows.push(
+            `<div>${t.emitted ? `yield {zoom:${t.z}, x:${t.x}..${t.x}, y:${t.y}..${t.y}}` : 'zoom &lt; minZoom \u2192 nothing emitted at this level'} <span class="mut">(FT-3.A.1)</span></div>`
+          );
+          rows.push(
+            `<div class="mut">${
+              t.z < span.maxZoom
+                ? `recurse \u2192 z=${t.z + 1}: (${2 * t.x},${2 * t.y}) (${2 * t.x + 1},${2 * t.y}) (${2 * t.x},${2 * t.y + 1}) (${2 * t.x + 1},${2 * t.y + 1})`
+                : 'z = maxZoom \u2192 no recursion (FT-3.A.2 skipped)'
+            }</div>`
+          );
+        } else if (t.path === 'B') {
+          rows.push(
+            `<div>yield subtreeRanges \u2192 ${t.emitted} block${t.emitted === 1 ? '' : 's'}, z = ${Math.max(t.z, span.minZoom)}..${span.maxZoom} <span class="mut">(FT-4.4)</span></div>`
+          );
+        } else {
+          rows.push(`<div class="mut">return — subtree never visited</div>`);
+        }
+        $('lines').innerHTML = rows.join('');
+        const doneTag = step === run.trace.length - 1 ? `<span style="color:${css('--green')};font-weight:700">done \u2713</span>` : '';
+        $('tallies').innerHTML =
+          `<span>ranges emitted <b>${run.emittedPrefix[step]}</b> / ${run.totalRanges}</span>` +
+          `<span>subtrees pruned <b>${run.prunedPrefix[step]}</b></span>` +
+          doneTag;
+      }
+      function render() {
+        if (!run) {
+          draw();
+          return;
+        }
+        step = Math.max(0, Math.min(step, run.trace.length - 1));
+        $('scrub').value = step;
+        renderLedger();
+        draw();
+      }
+
+      // ── playback ──────────────────────────────────────────────────────────────────
+      function stop() {
+        playing = false;
+        clearInterval(timer);
+        $('playBtn').textContent = 'Play';
+      }
+      function play() {
+        if (!run) return;
+        playing = true;
+        $('playBtn').textContent = 'Pause';
+        clearInterval(timer);
+        timer = setInterval(() => {
+          if (step >= run.trace.length - 1) {
+            stop();
+            return;
+          }
+          step++;
+          render();
+        }, 1000 / speed);
+      }
+
+      // ── wiring ────────────────────────────────────────────────────────────────────
+      function setDrawer(open) {
+        $('inputDrawer').classList.toggle('hidden', !open);
+        $('toggleInput').textContent = open ? 'Hide footprint input' : 'Edit footprint';
+      }
+      const presetsBox = $('presets');
+      Object.keys(PRESETS).forEach((name) => {
+        const b = document.createElement('button');
+        b.textContent = name;
+        b.onclick = () => {
+          $('geo').value = JSON.stringify(PRESETS[name].geo, null, 1);
+          $('minZoom').value = PRESETS[name].span.minZoom;
+          $('maxZoom').value = PRESETS[name].span.maxZoom;
+        };
+        presetsBox.appendChild(b);
+      });
+      $('geo').value = JSON.stringify(PRESETS['Australia + desert hole'].geo, null, 1);
+      $('runBtn').onclick = runTrace;
+      $('toggleInput').onclick = () => setDrawer($('inputDrawer').classList.contains('hidden'));
+      $('playBtn').onclick = () => (playing ? (stop(), render()) : play());
+      $('restart').onclick = () => {
+        stop();
+        step = 0;
+        render();
+      };
+      $('back').onclick = () => {
+        stop();
+        step--;
+        render();
+      };
+      $('fwd').onclick = () => {
+        stop();
+        step++;
+        render();
+      };
+      $('scrub').oninput = (e) => {
+        stop();
+        step = +e.target.value;
+        render();
+      };
+      $('speed').oninput = (e) => {
+        speed = +e.target.value;
+        $('speedVal').textContent = speed + '/s';
+        if (playing) play();
+      };
+      document.querySelectorAll('#viewBtns button').forEach((b) => {
+        b.onclick = () => {
+          viewMode = b.dataset.v;
+          document.querySelectorAll('#viewBtns button').forEach((x) => x.classList.toggle('on', x === b));
+          render();
+        };
+      });
+      window.addEventListener('keydown', (e) => {
+        if (!run || /TEXTAREA|INPUT/.test(e.target.tagName)) return;
+        if (e.key === 'ArrowRight') {
+          stop();
+          step++;
+          render();
+          e.preventDefault();
+        }
+        if (e.key === 'ArrowLeft') {
+          stop();
+          step--;
+          render();
+          e.preventDefault();
+        }
+        if (e.key === ' ') {
+          playing ? (stop(), render()) : play();
+          e.preventDefault();
+        }
+      });
+      window.addEventListener('resize', draw);
+      draw();
+    </script>
+  </body>
+</html>

--- a/src/geo/footprintToTileRanges.ts
+++ b/src/geo/footprintToTileRanges.ts
@@ -9,7 +9,7 @@ import { ITileRange } from '../models/interfaces/geo/iTile';
 import { Footprint } from './geoIntersection';
 import { degreesPerTile } from './tiles';
 
-interface ZoomSpan {
+interface ZoomRange {
   minZoom: number;
   maxZoom: number;
 }
@@ -140,7 +140,7 @@ function tileBounds(zoom: number, x: number, y: number): TileBounds {
 
 // emits the whole subtree of a tile proven fully inside the footprint — pure arithmetic,
 // no geometry tests: a coarse interior tile can stand in for millions of deep tiles
-function* subtreeRanges(zoom: number, x: number, y: number, span: ZoomSpan): Generator<ITileRange> {
+function* subtreeRanges(zoom: number, x: number, y: number, span: ZoomRange): Generator<ITileRange> {
   // Math.max skips levels above the requested span; the block is still derived from THIS node
   for (let z = Math.max(zoom, span.minZoom); z <= span.maxZoom; z++) {
     const factor = Math.pow(SUBTILES_PER_AXIS, z - zoom); // each level doubles both axes
@@ -153,7 +153,7 @@ function* subtreeRanges(zoom: number, x: number, y: number, span: ZoomSpan): Gen
 //   no edges cross + center inside  -> whole subtree is inside: emit it arithmetically
 //   no edges cross + center outside -> whole subtree is outside: prune it
 //   edges cross                     -> the tile intersects: emit it, recurse into 4 children
-function* descend(zoom: number, x: number, y: number, edges: Segment[], rings: Position[][], span: ZoomSpan): Generator<ITileRange> {
+function* descend(zoom: number, x: number, y: number, edges: Segment[], rings: Position[][], span: ZoomRange): Generator<ITileRange> {
   const bounds = tileBounds(zoom, x, y);
   // `edges` only holds edges that crossed the PARENT tile; re-filter for this tile, so the
   // list keeps shrinking as the descent narrows onto the boundary
@@ -164,7 +164,6 @@ function* descend(zoom: number, x: number, y: number, edges: Segment[], rings: P
     // lies uniformly inside or uniformly outside; any single interior point decides which
     const centerLon = midpoint(bounds.minLon, bounds.maxLon);
     const centerLat = midpoint(bounds.minLat, bounds.maxLat);
-    // the center can never lie exactly on the boundary here (no edges cross this tile)
     if (pointInRings(centerLon, centerLat, rings)) {
       yield* subtreeRanges(zoom, x, y, span);
     }
@@ -192,22 +191,25 @@ function* descend(zoom: number, x: number, y: number, edges: Segment[], rings: P
  * deterministic but otherwise unspecified. A tile touching the footprint with zero overlap
  * area counts as intersecting.
  * @param footprint footprint to cover, holes are supported
- * @param span inclusive zoom span to emit ranges for
+ * @param zoomRange inclusive zoom span, must be within [0, 22] and minZoom <= maxZoom
+ * @returns a generator of disjoint tile ranges, each with a single zoom level
  */
-export function* footprintToTileRanges(footprint: Footprint, span: ZoomSpan): Generator<ITileRange> {
-  if (span.minZoom > span.maxZoom) {
-    throw new RangeError(`minZoom [${span.minZoom}] must not be greater than maxZoom [${span.maxZoom}]`);
+export function* footprintToTileRanges(footprint: Footprint, zoomRange: ZoomRange): Generator<ITileRange> {
+  if (zoomRange.minZoom > zoomRange.maxZoom) {
+    throw new RangeError(`minZoom [${zoomRange.minZoom}] must not be greater than maxZoom [${zoomRange.maxZoom}]`);
   }
-  if (span.minZoom < MIN_SUPPORTED_ZOOM || span.maxZoom > MAX_SUPPORTED_ZOOM) {
-    throw new RangeError(`zoom span [${span.minZoom}, ${span.maxZoom}] exceeds the supported range [${MIN_SUPPORTED_ZOOM}, ${MAX_SUPPORTED_ZOOM}]`);
+  if (zoomRange.minZoom < MIN_SUPPORTED_ZOOM || zoomRange.maxZoom > MAX_SUPPORTED_ZOOM) {
+    throw new RangeError(
+      `zoom span [${zoomRange.minZoom}, ${zoomRange.maxZoom}] exceeds the supported range [${MIN_SUPPORTED_ZOOM}, ${MAX_SUPPORTED_ZOOM}]`
+    );
   }
 
   const rings = ringsOf(footprint);
   const edges = ringsToEdges(rings);
   // the geodetic grid has two root tiles (2x1) at zoom 0 — west (x=0) and east (x=1)
   // hemispheres — so the descent starts from both; the walk can only visit real grid tiles
-  yield* descend(0, 0, 0, edges, rings, span);
-  yield* descend(0, 1, 0, edges, rings, span);
+  yield* descend(0, 0, 0, edges, rings, zoomRange);
+  yield* descend(0, 1, 0, edges, rings, zoomRange);
 }
 
-export type { ZoomSpan };
+export type { ZoomRange };

--- a/src/geo/footprintToTileRanges.ts
+++ b/src/geo/footprintToTileRanges.ts
@@ -1,0 +1,214 @@
+/**
+ * Hierarchical precompute of the tiles intersecting a footprint (ADR 0001).
+ * The tile pyramid is a quadtree — tile (z, x, y) contains tiles (z+1, 2x..2x+1, 2y..2y+1) —
+ * so classifying one coarse tile can settle its entire subtree; the walk only recurses where
+ * the footprint's boundary passes, making total work O(boundary tiles), not O(bbox area).
+ * Evidence and benchmarks: simulation/README.md. Domain terms: CONTEXT.md.
+ */
+import type { Position } from 'geojson';
+import { ITileRange } from '../models/interfaces/geo/iTile';
+import { Footprint } from './geoIntersection';
+import { degreesPerTile } from './tiles';
+
+interface ZoomSpan {
+  minZoom: number;
+  maxZoom: number;
+}
+
+interface Segment {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+interface TileBounds {
+  minLon: number;
+  minLat: number;
+  maxLon: number;
+  maxLat: number;
+}
+
+const MIN_SUPPORTED_ZOOM = 0;
+const MAX_SUPPORTED_ZOOM = 22;
+const GRID_MIN_LON = -180;
+const GRID_MIN_LAT = -90;
+const SUBTILES_PER_AXIS = 2;
+
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+const midpoint = (a: number, b: number): number => (a + b) / 2;
+
+// normalizes any accepted footprint into a flat list of rings
+function ringsOf(footprint: Footprint): Position[][] {
+  const geometry = footprint.type === 'Feature' ? footprint.geometry : footprint;
+  if (geometry.type === 'Polygon') {
+    return geometry.coordinates;
+  }
+  // flattening MultiPolygon parts is safe: edge clipping and the even-odd point test are
+  // both ring-agnostic, so outer rings, holes and disjoint parts all work with one flat list
+  return geometry.coordinates.flat();
+}
+
+// converts rings to individual edges (each ring is closed: last point equals the first)
+function ringsToEdges(rings: Position[][]): Segment[] {
+  const edges: Segment[] = [];
+  for (const ring of rings) {
+    for (let i = 0; i < ring.length - 1; i++) {
+      edges.push({ x1: ring[i][0], y1: ring[i][1], x2: ring[i + 1][0], y2: ring[i + 1][1] });
+    }
+  }
+  return edges;
+}
+
+// Liang-Barsky line clipping as a boolean: does any part of the segment lie within the tile?
+// The segment is P(t) = start + t * (dx, dy) for t in [0, 1]; the loop shrinks the window
+// [t0, t1] of the part inside the tile. Touching a border counts as intersecting
+// docs: https://mapcolonies.atlassian.net/wiki/spaces/MAPConflicResolution/pages/3334111234/Liang-Barsky+intersection+predicate+segmentIntersectsBounds
+function segmentIntersectsBounds(segment: Segment, bounds: TileBounds): boolean {
+  const dx = segment.x2 - segment.x1;
+  const dy = segment.y2 - segment.y1;
+  const p = [-dx, dx, -dy, dy]; // speed toward each boundary: west, east, south, north
+  const q = [segment.x1 - bounds.minLon, bounds.maxLon - segment.x1, segment.y1 - bounds.minLat, bounds.maxLat - segment.y1]; // start point's signed distance inside each boundary
+  let t0 = 0; // window start: latest entry crossing seen so far
+  let t1 = 1; // window end: earliest exit crossing seen so far
+
+  for (let i = 0; i < p.length; i++) {
+    // docs: #LB-2.1
+    if (p[i] === 0) {
+      // parallel to boundary i, so it never crosses it
+      if (q[i] < 0) {
+        // and it runs on the outside of that boundary -> the whole segment is out (docs: #LB-2.1.A  (path P1))
+        return false;
+      }
+    } else {
+      const r = q[i] / p[i]; // the t at which the segment crosses boundary i
+      // docs: #LB-2.2
+      if (p[i] < 0) {
+        // moving toward the inside: r is an ENTRY point
+        if (r > t1) {
+          return false; // enters only after it already exited elsewhere -> misses the tile (docs: #LB-2.2.A  (path P2))
+        }
+        if (r > t0) {
+          t0 = r; // docs: #LB-2.2.B
+        }
+      } else {
+        // moving toward the outside: r is an EXIT point (docs: #LB-2.3)
+        if (r < t0) {
+          return false; // exits before it ever entered -> misses the tile (docs: #LB-2.3.A  (path P3))
+        }
+        if (r < t1) {
+          t1 = r; // docs: #LB-2.3.B
+        }
+      }
+    }
+  }
+  // a valid window remains; t0 === t1 means a single touch point, which still counts
+  return true; // docs: #LB-3  (path P4)
+}
+
+// even-odd (ray casting) point-in-polygon: cast a ray east from the point and count edge
+// crossings — odd total means inside. One shared toggle across all rings is what makes
+// holes and MultiPolygon parts work with no special casing (inside outer + inside hole
+// toggles twice = outside).
+function pointInRings(lon: number, lat: number, rings: Position[][]): boolean {
+  let inside = false;
+  for (const ring of rings) {
+    for (let i = 0; i < ring.length - 1; i++) {
+      const [x1, y1] = ring[i];
+      const [x2, y2] = ring[i + 1];
+      // half-open test (<= vs >): a shared vertex is counted for exactly one of its two
+      // edges, and horizontal edges (y1 === y2) never match — both avoid double counting
+      if ((y1 <= lat && y2 > lat) || (y2 <= lat && y1 > lat)) {
+        const xCross = x1 + ((lat - y1) * (x2 - x1)) / (y2 - y1); // longitude where the edge crosses the ray's latitude (linear interpolation)
+        if (xCross > lon) {
+          // the crossing is east of the point, i.e. actually on the ray
+          inside = !inside;
+        }
+      }
+    }
+  }
+  return inside;
+}
+
+// bounds of a tile on the WGS84 geodetic grid: tiles span 180 / 2^z degrees, origin at the
+// south-west corner (-180, -90), x grows east (two hemispheres wide), y grows north
+function tileBounds(zoom: number, x: number, y: number): TileBounds {
+  const span = degreesPerTile(zoom);
+  const minLon = GRID_MIN_LON + x * span;
+  const minLat = GRID_MIN_LAT + y * span;
+  return { minLon, minLat, maxLon: minLon + span, maxLat: minLat + span };
+}
+
+// emits the whole subtree of a tile proven fully inside the footprint — pure arithmetic,
+// no geometry tests: a coarse interior tile can stand in for millions of deep tiles
+function* subtreeRanges(zoom: number, x: number, y: number, span: ZoomSpan): Generator<ITileRange> {
+  // Math.max skips levels above the requested span; the block is still derived from THIS node
+  for (let z = Math.max(zoom, span.minZoom); z <= span.maxZoom; z++) {
+    const factor = Math.pow(SUBTILES_PER_AXIS, z - zoom); // each level doubles both axes
+    // the block this tile covers at level z: x' in [x * factor, (x + 1) * factor - 1], y' likewise
+    yield { zoom: z, minX: x * factor, maxX: (x + 1) * factor - 1, minY: y * factor, maxY: (y + 1) * factor - 1 };
+  }
+}
+
+// the hierarchical descent: classify a tile into one of three outcomes —
+//   no edges cross + center inside  -> whole subtree is inside: emit it arithmetically
+//   no edges cross + center outside -> whole subtree is outside: prune it
+//   edges cross                     -> the tile intersects: emit it, recurse into 4 children
+function* descend(zoom: number, x: number, y: number, edges: Segment[], rings: Position[][], span: ZoomSpan): Generator<ITileRange> {
+  const bounds = tileBounds(zoom, x, y);
+  // `edges` only holds edges that crossed the PARENT tile; re-filter for this tile, so the
+  // list keeps shrinking as the descent narrows onto the boundary
+  const clipped = edges.filter((edge) => segmentIntersectsBounds(edge, bounds));
+
+  if (clipped.length === 0) {
+    // the boundary does not pass through this tile, and a tile is a connected region — so it
+    // lies uniformly inside or uniformly outside; any single interior point decides which
+    const centerLon = midpoint(bounds.minLon, bounds.maxLon);
+    const centerLat = midpoint(bounds.minLat, bounds.maxLat);
+    // the center can never lie exactly on the boundary here (no edges cross this tile)
+    if (pointInRings(centerLon, centerLat, rings)) {
+      yield* subtreeRanges(zoom, x, y, span);
+    }
+    return; // center outside -> prune: no descendant can intersect
+  }
+
+  if (zoom >= span.minZoom) {
+    // the boundary passes through this tile, and a polygon includes its boundary -> the tile
+    // itself intersects; emit it as a 1x1 range (only when inside the requested span)
+    yield { zoom, minX: x, maxX: x, minY: y, maxY: y };
+  }
+  if (zoom < span.maxZoom) {
+    const childX = SUBTILES_PER_AXIS * x; // children occupy the doubled coordinates:
+    const childY = SUBTILES_PER_AXIS * y; // x' in {2x, 2x+1}, y' in {2y, 2y+1}
+    yield* descend(zoom + 1, childX, childY, clipped, rings, span);
+    yield* descend(zoom + 1, childX + 1, childY, clipped, rings, span);
+    yield* descend(zoom + 1, childX, childY + 1, clipped, rings, span);
+    yield* descend(zoom + 1, childX + 1, childY + 1, clipped, rings, span);
+  }
+}
+
+/**
+ * computes the tile ranges intersecting the given footprint for every zoom level in the
+ * span, using hierarchical descent. Ranges of the same zoom are disjoint; their order is
+ * deterministic but otherwise unspecified. A tile touching the footprint with zero overlap
+ * area counts as intersecting.
+ * @param footprint footprint to cover, holes are supported
+ * @param span inclusive zoom span to emit ranges for
+ */
+export function* footprintToTileRanges(footprint: Footprint, span: ZoomSpan): Generator<ITileRange> {
+  if (span.minZoom > span.maxZoom) {
+    throw new RangeError(`minZoom [${span.minZoom}] must not be greater than maxZoom [${span.maxZoom}]`);
+  }
+  if (span.minZoom < MIN_SUPPORTED_ZOOM || span.maxZoom > MAX_SUPPORTED_ZOOM) {
+    throw new RangeError(`zoom span [${span.minZoom}, ${span.maxZoom}] exceeds the supported range [${MIN_SUPPORTED_ZOOM}, ${MAX_SUPPORTED_ZOOM}]`);
+  }
+
+  const rings = ringsOf(footprint);
+  const edges = ringsToEdges(rings);
+  // the geodetic grid has two root tiles (2x1) at zoom 0 — west (x=0) and east (x=1)
+  // hemispheres — so the descent starts from both; the walk can only visit real grid tiles
+  yield* descend(0, 0, 0, edges, rings, span);
+  yield* descend(0, 1, 0, edges, rings, span);
+}
+
+export type { ZoomSpan };

--- a/src/geo/footprintToTileRanges.ts
+++ b/src/geo/footprintToTileRanges.ts
@@ -132,17 +132,17 @@ function pointInRings(lon: number, lat: number, rings: Position[][]): boolean {
 // bounds of a tile on the WGS84 geodetic grid: tiles span 180 / 2^z degrees, origin at the
 // south-west corner (-180, -90), x grows east (two hemispheres wide), y grows north
 function tileBounds(zoom: number, x: number, y: number): TileBounds {
-  const span = degreesPerTile(zoom);
-  const minLon = GRID_MIN_LON + x * span;
-  const minLat = GRID_MIN_LAT + y * span;
-  return { minLon, minLat, maxLon: minLon + span, maxLat: minLat + span };
+  const degrees = degreesPerTile(zoom);
+  const minLon = GRID_MIN_LON + x * degrees;
+  const minLat = GRID_MIN_LAT + y * degrees;
+  return { minLon, minLat, maxLon: minLon + degrees, maxLat: minLat + degrees };
 }
 
 // emits the whole subtree of a tile proven fully inside the footprint — pure arithmetic,
 // no geometry tests: a coarse interior tile can stand in for millions of deep tiles
-function* subtreeRanges(zoom: number, x: number, y: number, span: ZoomRange): Generator<ITileRange> {
-  // Math.max skips levels above the requested span; the block is still derived from THIS node
-  for (let z = Math.max(zoom, span.minZoom); z <= span.maxZoom; z++) {
+function* subtreeRanges(zoom: number, x: number, y: number, range: ZoomRange): Generator<ITileRange> {
+  // Math.max skips levels above the requested range; the block is still derived from THIS node
+  for (let z = Math.max(zoom, range.minZoom); z <= range.maxZoom; z++) {
     const factor = Math.pow(SUBTILES_PER_AXIS, z - zoom); // each level doubles both axes
     // the block this tile covers at level z: x' in [x * factor, (x + 1) * factor - 1], y' likewise
     yield { zoom: z, minX: x * factor, maxX: (x + 1) * factor - 1, minY: y * factor, maxY: (y + 1) * factor - 1 };
@@ -153,7 +153,7 @@ function* subtreeRanges(zoom: number, x: number, y: number, span: ZoomRange): Ge
 //   no edges cross + center inside  -> whole subtree is inside: emit it arithmetically
 //   no edges cross + center outside -> whole subtree is outside: prune it
 //   edges cross                     -> the tile intersects: emit it, recurse into 4 children
-function* descend(zoom: number, x: number, y: number, edges: Segment[], rings: Position[][], span: ZoomRange): Generator<ITileRange> {
+function* descend(zoom: number, x: number, y: number, edges: Segment[], rings: Position[][], range: ZoomRange): Generator<ITileRange> {
   const bounds = tileBounds(zoom, x, y);
   // `edges` only holds edges that crossed the PARENT tile; re-filter for this tile, so the
   // list keeps shrinking as the descent narrows onto the boundary
@@ -165,42 +165,42 @@ function* descend(zoom: number, x: number, y: number, edges: Segment[], rings: P
     const centerLon = midpoint(bounds.minLon, bounds.maxLon);
     const centerLat = midpoint(bounds.minLat, bounds.maxLat);
     if (pointInRings(centerLon, centerLat, rings)) {
-      yield* subtreeRanges(zoom, x, y, span);
+      yield* subtreeRanges(zoom, x, y, range);
     }
     return; // center outside -> prune: no descendant can intersect
   }
 
-  if (zoom >= span.minZoom) {
+  if (zoom >= range.minZoom) {
     // the boundary passes through this tile, and a polygon includes its boundary -> the tile
-    // itself intersects; emit it as a 1x1 range (only when inside the requested span)
+    // itself intersects; emit it as a 1x1 range (only when inside the requested range)
     yield { zoom, minX: x, maxX: x, minY: y, maxY: y };
   }
-  if (zoom < span.maxZoom) {
+  if (zoom < range.maxZoom) {
     const childX = SUBTILES_PER_AXIS * x; // children occupy the doubled coordinates:
     const childY = SUBTILES_PER_AXIS * y; // x' in {2x, 2x+1}, y' in {2y, 2y+1}
-    yield* descend(zoom + 1, childX, childY, clipped, rings, span);
-    yield* descend(zoom + 1, childX + 1, childY, clipped, rings, span);
-    yield* descend(zoom + 1, childX, childY + 1, clipped, rings, span);
-    yield* descend(zoom + 1, childX + 1, childY + 1, clipped, rings, span);
+    yield* descend(zoom + 1, childX, childY, clipped, rings, range);
+    yield* descend(zoom + 1, childX + 1, childY, clipped, rings, range);
+    yield* descend(zoom + 1, childX, childY + 1, clipped, rings, range);
+    yield* descend(zoom + 1, childX + 1, childY + 1, clipped, rings, range);
   }
 }
 
 /**
  * computes the tile ranges intersecting the given footprint for every zoom level in the
- * span, using hierarchical descent. Ranges of the same zoom are disjoint; their order is
+ * range, using hierarchical descent. Ranges of the same zoom are disjoint; their order is
  * deterministic but otherwise unspecified. A tile touching the footprint with zero overlap
  * area counts as intersecting.
  * @param footprint footprint to cover, holes are supported
- * @param zoomRange inclusive zoom span, must be within [0, 22] and minZoom <= maxZoom
+ * @param range inclusive zoom range, must be within [0, 22] and minZoom <= maxZoom
  * @returns a generator of disjoint tile ranges, each with a single zoom level
  */
-export function* footprintToTileRanges(footprint: Footprint, zoomRange: ZoomRange): Generator<ITileRange> {
-  if (zoomRange.minZoom > zoomRange.maxZoom) {
-    throw new RangeError(`minZoom [${zoomRange.minZoom}] must not be greater than maxZoom [${zoomRange.maxZoom}]`);
+export function* footprintToTileRanges(footprint: Footprint, range: ZoomRange): Generator<ITileRange> {
+  if (range.minZoom > range.maxZoom) {
+    throw new RangeError(`minZoom [${range.minZoom}] must not be greater than maxZoom [${range.maxZoom}]`);
   }
-  if (zoomRange.minZoom < MIN_SUPPORTED_ZOOM || zoomRange.maxZoom > MAX_SUPPORTED_ZOOM) {
+  if (range.minZoom < MIN_SUPPORTED_ZOOM || range.maxZoom > MAX_SUPPORTED_ZOOM) {
     throw new RangeError(
-      `zoom span [${zoomRange.minZoom}, ${zoomRange.maxZoom}] exceeds the supported range [${MIN_SUPPORTED_ZOOM}, ${MAX_SUPPORTED_ZOOM}]`
+      `zoom range [${range.minZoom}, ${range.maxZoom}] exceeds the supported range [${MIN_SUPPORTED_ZOOM}, ${MAX_SUPPORTED_ZOOM}]`
     );
   }
 
@@ -208,8 +208,8 @@ export function* footprintToTileRanges(footprint: Footprint, zoomRange: ZoomRang
   const edges = ringsToEdges(rings);
   // the geodetic grid has two root tiles (2x1) at zoom 0 — west (x=0) and east (x=1)
   // hemispheres — so the descent starts from both; the walk can only visit real grid tiles
-  yield* descend(0, 0, 0, edges, rings, zoomRange);
-  yield* descend(0, 1, 0, edges, rings, zoomRange);
+  yield* descend(0, 0, 0, edges, rings, range);
+  yield* descend(0, 1, 0, edges, rings, range);
 }
 
 export type { ZoomRange };

--- a/src/geo/footprintToTileRanges.ts
+++ b/src/geo/footprintToTileRanges.ts
@@ -1,9 +1,8 @@
 /**
- * Hierarchical precompute of the tiles intersecting a footprint (ADR 0001).
- * The tile pyramid is a quadtree — tile (z, x, y) contains tiles (z+1, 2x..2x+1, 2y..2y+1) —
+ * Hierarchical precompute of the tiles intersecting a footprint.
+ * The tile pyramid is a quadtree — tile (z, x, y) contains tiles (z+1, 2x..2x+1, 2y..2y+1) -
  * so classifying one coarse tile can settle its entire subtree; the walk only recurses where
  * the footprint's boundary passes, making total work O(boundary tiles), not O(bbox area).
- * Evidence and benchmarks: simulation/README.md. Domain terms: CONTEXT.md.
  */
 import type { Position } from 'geojson';
 import { ITileRange } from '../models/interfaces/geo/iTile';

--- a/src/geo/index.ts
+++ b/src/geo/index.ts
@@ -1,4 +1,5 @@
 export * from './bboxUtils';
+export * from './footprintToTileRanges';
 export * from './geoConvertor';
 export * from './geoHash';
 export * from './geoIntersection';

--- a/tests/unit/geo/footprintToTileRanges.spec.ts
+++ b/tests/unit/geo/footprintToTileRanges.spec.ts
@@ -1,0 +1,172 @@
+import type { Feature, MultiPolygon, Polygon } from 'geojson';
+import { bboxPolygon, booleanDisjoint, bbox as turfBbox } from '@turf/turf';
+import { ITileRange } from '../../../src/models/interfaces/geo/iTile';
+import { footprintToTileRanges } from '../../../src/geo/footprintToTileRanges';
+import { Footprint } from '../../../src/geo/geoIntersection';
+import { degreesPerTile } from '../../../src/geo/tiles';
+
+// exhaustive ground truth (see ADR 0001): test every candidate tile in the footprint's bbox
+// (padded by one tile so boundary-touching neighbors are candidates too) with the same
+// inclusive intersection predicate the production algorithm must honor
+const oracleTileSet = (footprint: Footprint, minZoom: number, maxZoom: number): Set<string> => {
+  const tiles = new Set<string>();
+  const [minLon, minLat, maxLon, maxLat] = turfBbox(footprint);
+  for (let zoom = minZoom; zoom <= maxZoom; zoom++) {
+    const resolution = degreesPerTile(zoom);
+    const cols = 2 * Math.pow(2, zoom);
+    const rows = Math.pow(2, zoom);
+    const minX = Math.max(0, Math.floor((minLon + 180) / resolution) - 1);
+    const maxX = Math.min(cols - 1, Math.floor((maxLon + 180) / resolution) + 1);
+    const minY = Math.max(0, Math.floor((minLat + 90) / resolution) - 1);
+    const maxY = Math.min(rows - 1, Math.floor((maxLat + 90) / resolution) + 1);
+    for (let x = minX; x <= maxX; x++) {
+      for (let y = minY; y <= maxY; y++) {
+        const tilePolygon = bboxPolygon([x * resolution - 180, y * resolution - 90, (x + 1) * resolution - 180, (y + 1) * resolution - 90]);
+        if (!booleanDisjoint(tilePolygon, footprint)) {
+          tiles.add(`${zoom}/${x}/${y}`);
+        }
+      }
+    }
+  }
+  return tiles;
+};
+
+const expandToTileSet = (ranges: Iterable<ITileRange>): Set<string> => {
+  const tiles = new Set<string>();
+  for (const range of ranges) {
+    for (let x = range.minX; x <= range.maxX; x++) {
+      for (let y = range.minY; y <= range.maxY; y++) {
+        tiles.add(`${range.zoom}/${x}/${y}`);
+      }
+    }
+  }
+  return tiles;
+};
+
+const squarePolygon = (minLon: number, minLat: number, maxLon: number, maxLat: number): Polygon => ({
+  type: 'Polygon',
+  coordinates: [
+    [
+      [minLon, minLat],
+      [maxLon, minLat],
+      [maxLon, maxLat],
+      [minLon, maxLat],
+      [minLon, minLat],
+    ],
+  ],
+});
+
+describe('footprintToTileRanges', () => {
+  describe('zoom span validation', () => {
+    it('should throw RangeError when minZoom is greater than maxZoom', () => {
+      const footprint = squarePolygon(0, 0, 90, 90);
+
+      const generate = () => [...footprintToTileRanges(footprint, { minZoom: 5, maxZoom: 3 })];
+
+      expect(generate).toThrow(RangeError);
+    });
+
+    it.each([
+      [-1, 5],
+      [0, 23],
+    ])('should throw RangeError when the span [%i, %i] exceeds the supported zoom levels', (minZoom, maxZoom) => {
+      const footprint = squarePolygon(0, 0, 90, 90);
+
+      const generate = () => [...footprintToTileRanges(footprint, { minZoom, maxZoom })];
+
+      expect(generate).toThrow(RangeError);
+    });
+  });
+
+  describe('tile coverage', () => {
+    it.only('should yield exactly the two root tiles for a world-covering footprint at zoom 0', () => {
+      const footprint = squarePolygon(-180, -90, 180, 90);
+
+      const tiles = expandToTileSet(footprintToTileRanges(footprint, { minZoom: 0, maxZoom: 0 }));
+
+      expect(tiles).toEqual(new Set(['0/0/0', '0/1/0']));
+    });
+
+    it('should include tiles that only touch the footprint boundary with zero overlap area', () => {
+      // footprint aligned exactly to the zoom 2 grid (tile resolution 45 degrees): it fills
+      // tile (4,2) and touches all 8 neighbors along edges/corners without overlapping them
+      const footprint = squarePolygon(0, 0, 45, 45);
+
+      const tiles = expandToTileSet(footprintToTileRanges(footprint, { minZoom: 2, maxZoom: 2 }));
+
+      expect(tiles).toEqual(new Set(['2/3/1', '2/4/1', '2/5/1', '2/3/2', '2/4/2', '2/5/2', '2/3/3', '2/4/3', '2/5/3']));
+    });
+  });
+
+  describe('brute-force parity', () => {
+    const donut: Polygon = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [34.7, 31.2],
+          [35.3, 31.2],
+          [35.3, 31.9],
+          [34.7, 31.9],
+          [34.7, 31.2],
+        ],
+        [
+          [34.9, 31.4],
+          [35.1, 31.4],
+          [35.1, 31.7],
+          [34.9, 31.7],
+          [34.9, 31.4],
+        ],
+      ],
+    };
+
+    const disjointMultiPolygon: MultiPolygon = {
+      type: 'MultiPolygon',
+      coordinates: [squarePolygon(10, 10, 10.5, 10.5).coordinates, squarePolygon(40, -20, 40.4, -19.6).coordinates],
+    };
+
+    const thinSliver: Polygon = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [34.7, 31.2],
+          [35.3, 31.9],
+          [35.3005, 31.9],
+          [34.7005, 31.2],
+          [34.7, 31.2],
+        ],
+      ],
+    };
+
+    const rectangleFeature: Feature<Polygon> = {
+      type: 'Feature',
+      properties: {},
+      geometry: squarePolygon(34.72, 31.23, 35.28, 31.87),
+    };
+
+    it.each<[string, Footprint, number, number]>([
+      ['off-grid rectangle', squarePolygon(34.72, 31.23, 35.28, 31.87), 0, 8],
+      ['donut with a hole', donut, 0, 10],
+      ['disjoint MultiPolygon parts', disjointMultiPolygon, 2, 8],
+      ['adversarial thin sliver', thinSliver, 4, 12],
+      ['Feature-wrapped rectangle', rectangleFeature, 3, 8],
+    ])('should match the exhaustive oracle key-by-key for a %s', (_name, footprint, minZoom, maxZoom) => {
+      const tiles = expandToTileSet(footprintToTileRanges(footprint, { minZoom, maxZoom }));
+
+      expect(tiles).toEqual(oracleTileSet(footprint, minZoom, maxZoom));
+    });
+
+    it('should emit disjoint ranges per zoom level', () => {
+      const ranges = [...footprintToTileRanges(donut, { minZoom: 0, maxZoom: 10 })];
+
+      const totalTiles = ranges.reduce((sum, range) => sum + (range.maxX - range.minX + 1) * (range.maxY - range.minY + 1), 0);
+      expect(totalTiles).toBe(expandToTileSet(ranges).size);
+    });
+
+    it('should be deterministic across runs', () => {
+      const first = [...footprintToTileRanges(thinSliver, { minZoom: 0, maxZoom: 10 })];
+      const second = [...footprintToTileRanges(thinSliver, { minZoom: 0, maxZoom: 10 })];
+
+      expect(second).toEqual(first);
+    });
+  });
+});

--- a/tests/unit/geo/footprintToTileRanges.spec.ts
+++ b/tests/unit/geo/footprintToTileRanges.spec.ts
@@ -57,7 +57,7 @@ const squarePolygon = (minLon: number, minLat: number, maxLon: number, maxLat: n
 });
 
 describe('footprintToTileRanges', () => {
-  describe('zoom span validation', () => {
+  describe('zoom range validation', () => {
     it('should throw RangeError when minZoom is greater than maxZoom', () => {
       const footprint = squarePolygon(0, 0, 90, 90);
 
@@ -69,7 +69,7 @@ describe('footprintToTileRanges', () => {
     it.each([
       [-1, 5],
       [0, 23],
-    ])('should throw RangeError when the span [%i, %i] exceeds the supported zoom levels', (minZoom, maxZoom) => {
+    ])('should throw RangeError when the range [%i, %i] exceeds the supported zoom levels', (minZoom, maxZoom) => {
       const footprint = squarePolygon(0, 0, 90, 90);
 
       const generate = () => [...footprintToTileRanges(footprint, { minZoom, maxZoom })];

--- a/tests/unit/geo/footprintToTileRanges.spec.ts
+++ b/tests/unit/geo/footprintToTileRanges.spec.ts
@@ -79,7 +79,7 @@ describe('footprintToTileRanges', () => {
   });
 
   describe('tile coverage', () => {
-    it.only('should yield exactly the two root tiles for a world-covering footprint at zoom 0', () => {
+    it('should yield exactly the two root tiles for a world-covering footprint at zoom 0', () => {
       const footprint = squarePolygon(-180, -90, 180, 90);
 
       const tiles = expandToTileSet(footprintToTileRanges(footprint, { minZoom: 0, maxZoom: 0 }));

--- a/tests/unit/geo/footprintToTileRanges.spec.ts
+++ b/tests/unit/geo/footprintToTileRanges.spec.ts
@@ -5,7 +5,7 @@ import { footprintToTileRanges } from '../../../src/geo/footprintToTileRanges';
 import { Footprint } from '../../../src/geo/geoIntersection';
 import { degreesPerTile } from '../../../src/geo/tiles';
 
-// exhaustive ground truth (see ADR 0001): test every candidate tile in the footprint's bbox
+// exhaustive ground truth: test every candidate tile in the footprint's bbox
 // (padded by one tile so boundary-touching neighbors are candidates too) with the same
 // inclusive intersection predicate the production algorithm must honor
 const oracleTileSet = (footprint: Footprint, minZoom: number, maxZoom: number): Set<string> => {


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| New feature     | ✔                                                                        |
| Documentation   | ✔                                                                        |
| Tests added     | ✔                                                                        |


Further  information:
Adds a new geometry-only API that computes, for a footprint (Polygon / MultiPolygon / Feature, holes supported) and an inclusive zoom span, all intersecting tiles on the WGS84 geodetic 2:1 grid — emitted lazily as compressed ITileRanges.

How the algorithm works:
The tile pyramid is a quadtree: tile (z, x, y) contains exactly tiles (z+1, 2x..2x+1, 2y..2y+1), so classifying one coarse tile can settle its entire subtree. Starting from the grid's two zoom-0 root tiles, each visited tile is classified by filtering the footprint's edge list against its bounds (Liang-Barsky clipping):

- No edges cross, center inside → the boundary doesn't pass through the tile, and a tile is a connected region, so it's uniformly inside. Its whole subtree is emitted arithmetically — one range per zoom level, zero further geometry work. This is how a coarse tile stands in for millions of deep ones.
- No edges cross, center outside → uniformly outside; the whole subtree is pruned.
- Edges cross → the boundary passes through, so the tile intersects (a polygon includes its boundary). Emit it and recurse into its 4 children, passing only the surviving edges — the edge list shrinks as the descent converges onto the boundary, keeping deep nodes cheap.

Recursion therefore only follows the footprint's boundary: total geometry work is O(boundary tiles at maxZoom) instead of O(bbox area × zoom levels). Interior bulk and exterior bulk are both settled at the coarsest possible level, which is also why memory stays flat — interior subtrees never get expanded, they're expressed as ranges. Point-in-polygon uses the even-odd ray-casting rule, which makes holes and MultiPolygon parts work with no special casing.

